### PR TITLE
feat: add in-app auto-update with download and install

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.sdvsync"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2
-        versionName = "0.0.2"
+        versionCode = 7
+        versionName = "0.0.7"
     }
 
     signingConfigs {
@@ -57,6 +57,13 @@ android {
     }
 
     androidResources { noCompress += "zip" }
+
+    applicationVariants.all {
+        outputs.all {
+            (this as com.android.build.gradle.internal.api.BaseVariantOutputImpl)
+                .outputFileName = "CinderboxCompanion-v$versionName.apk"
+        }
+    }
 
     packaging {
         resources {

--- a/app/src/main/java/com/sdvsync/MainActivity.kt
+++ b/app/src/main/java/com/sdvsync/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -30,6 +32,7 @@ import androidx.navigation.navArgument
 import com.sdvsync.logging.AppLogger
 import com.sdvsync.mods.ModDownloadManager
 import com.sdvsync.mods.api.NexusModSource
+import com.sdvsync.ui.components.AppUpdateDialog
 import com.sdvsync.ui.components.BottomTab
 import com.sdvsync.ui.components.StardewBottomBar
 import com.sdvsync.ui.screens.BackupListScreen
@@ -45,6 +48,7 @@ import com.sdvsync.ui.screens.SettingsScreen
 import com.sdvsync.ui.screens.SyncDetailScreen
 import com.sdvsync.ui.screens.SyncLogScreen
 import com.sdvsync.ui.theme.SdvSyncTheme
+import com.sdvsync.ui.viewmodels.AppUpdateViewModel
 import com.sdvsync.ui.viewmodels.InstalledModDetailViewModel
 import com.sdvsync.ui.viewmodels.ModBrowseViewModel
 import com.sdvsync.ui.viewmodels.ModDetailViewModel
@@ -345,6 +349,11 @@ fun SdvSyncNavGraph(navController: NavHostController) {
 
 @Composable
 fun MainScreen(parentNavController: NavHostController, showBottomBar: Boolean, selectedTab: BottomTab) {
+    val updateViewModel: AppUpdateViewModel = koinViewModel()
+    val updateState by updateViewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) { updateViewModel.checkForUpdate() }
+
     val mainNavController = rememberNavController()
     val mainBackStackEntry by mainNavController.currentBackStackEntryAsState()
     val mainCurrentRoute by remember(mainBackStackEntry) {
@@ -453,5 +462,23 @@ fun MainScreen(parentNavController: NavHostController, showBottomBar: Boolean, s
                 )
             }
         }
+    }
+
+    if (updateState.showDialog && updateState.updateInfo != null) {
+        AppUpdateDialog(
+            updateInfo = updateState.updateInfo!!,
+            state = updateState,
+            onDismiss = updateViewModel::dismiss,
+            onCancelDownload = updateViewModel::cancelDownload,
+            onSkipVersion = updateViewModel::skipVersion,
+            onUpdate = if (updateState.downloadError !=
+                null
+            ) {
+                updateViewModel::retryDownload
+            } else {
+                updateViewModel::startDownload
+            },
+            onInstallPermissionGranted = updateViewModel::onInstallPermissionGranted
+        )
     }
 }

--- a/app/src/main/java/com/sdvsync/di/AppModule.kt
+++ b/app/src/main/java/com/sdvsync/di/AppModule.kt
@@ -1,5 +1,6 @@
 package com.sdvsync.di
 
+import com.sdvsync.download.AppUpdateManager
 import com.sdvsync.download.GameDownloadManager
 import com.sdvsync.download.GitHubReleaseChecker
 import com.sdvsync.fileaccess.FileAccessDetector
@@ -25,6 +26,7 @@ import com.sdvsync.steam.SteamSessionStore
 import com.sdvsync.sync.ConflictResolver
 import com.sdvsync.sync.SyncEngine
 import com.sdvsync.sync.SyncHistoryStore
+import com.sdvsync.ui.viewmodels.AppUpdateViewModel
 import com.sdvsync.ui.viewmodels.BackupListViewModel
 import com.sdvsync.ui.viewmodels.DashboardViewModel
 import com.sdvsync.ui.viewmodels.GameDownloadViewModel
@@ -61,6 +63,7 @@ val appModule = module {
     single { SteamContentService(get()) }
     single { GitHubReleaseChecker(androidContext(), get()) }
     single { GameDownloadManager(androidContext(), get(), get()) }
+    single { AppUpdateManager(androidContext(), get(), get()) }
 
     // File access
     single { FileAccessDetector(androidContext()) }
@@ -100,7 +103,7 @@ val appModule = module {
     viewModel { LoginViewModel(get()) }
     viewModel { DashboardViewModel(androidContext(), get(), get(), get(), get(), get(), get()) }
     viewModel { SyncDetailViewModel(androidContext(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { SettingsViewModel(androidContext(), get(), get(), get(), get(), get(), get()) }
+    viewModel { SettingsViewModel(androidContext(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { SyncLogViewModel(get()) }
     viewModel { GameDownloadViewModel(androidContext(), get(), get(), get(), get()) }
     viewModel { ModManagerViewModel(androidContext(), get(), get(), get()) }
@@ -109,4 +112,5 @@ val appModule = module {
     viewModel { (uniqueId: String) -> InstalledModDetailViewModel(get(), get(), get(), get(), uniqueId) }
     viewModel { BackupListViewModel(androidContext(), get(), get(), get()) }
     viewModel { SaveViewerViewModel(androidContext(), get(), get()) }
+    viewModel { AppUpdateViewModel(get(), get()) }
 }

--- a/app/src/main/java/com/sdvsync/download/AppUpdateManager.kt
+++ b/app/src/main/java/com/sdvsync/download/AppUpdateManager.kt
@@ -1,0 +1,97 @@
+package com.sdvsync.download
+
+import android.content.Context
+import com.sdvsync.BuildConfig
+import com.sdvsync.logging.AppLogger
+import java.io.File
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class AppUpdateManager(
+    private val context: Context,
+    private val httpClient: OkHttpClient,
+    private val releaseChecker: GitHubReleaseChecker
+) {
+    companion object {
+        private const val TAG = "AppUpdateManager"
+        private const val PREFS_NAME = "app_update"
+        private const val KEY_UPDATE_CHECK_ENABLED = "update_check_enabled"
+        private const val KEY_SKIPPED_VERSION = "skipped_version"
+    }
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun isUpdateCheckEnabled(): Boolean = prefs.getBoolean(KEY_UPDATE_CHECK_ENABLED, true)
+
+    fun setUpdateCheckEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_UPDATE_CHECK_ENABLED, enabled).apply()
+    }
+
+    fun getSkippedVersion(): String? = prefs.getString(KEY_SKIPPED_VERSION, null)
+
+    fun setSkippedVersion(version: String?) {
+        prefs.edit().apply {
+            if (version == null) remove(KEY_SKIPPED_VERSION) else putString(KEY_SKIPPED_VERSION, version)
+        }.apply()
+    }
+
+    fun shouldShowUpdate(latestVersion: String): Boolean {
+        if (!isUpdateCheckEnabled()) return false
+        if (!releaseChecker.isUpdateAvailable(BuildConfig.VERSION_NAME, latestVersion)) return false
+        if (latestVersion == getSkippedVersion()) return false
+        return true
+    }
+
+    fun canInstallPackages(): Boolean = context.packageManager.canRequestPackageInstalls()
+
+    suspend fun downloadUpdate(assetUrl: String, assetName: String, onProgress: (Float) -> Unit): File? =
+        withContext(Dispatchers.IO) {
+            val destFile = File(context.cacheDir, assetName)
+            try {
+                val request = Request.Builder().url(assetUrl).get().build()
+                val response = httpClient.newCall(request).execute()
+
+                if (!response.isSuccessful) {
+                    response.close()
+                    AppLogger.e(TAG, "HTTP ${response.code} downloading $assetName")
+                    return@withContext null
+                }
+
+                val body = response.body ?: run {
+                    response.close()
+                    AppLogger.e(TAG, "Empty response body for $assetName")
+                    return@withContext null
+                }
+
+                val totalBytes = body.contentLength()
+                var downloadedBytes = 0L
+                val buffer = ByteArray(64 * 1024)
+
+                destFile.outputStream().buffered().use { output ->
+                    body.byteStream().use { input ->
+                        var bytesRead: Int
+                        while (input.read(buffer).also { bytesRead = it } != -1) {
+                            coroutineContext.ensureActive()
+                            output.write(buffer, 0, bytesRead)
+                            downloadedBytes += bytesRead
+                            if (totalBytes > 0) {
+                                onProgress(downloadedBytes.toFloat() / totalBytes)
+                            }
+                        }
+                    }
+                }
+
+                AppLogger.i(TAG, "App update downloaded: ${destFile.length()} bytes")
+                destFile
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                AppLogger.e(TAG, "App update download failed", e)
+                destFile.delete()
+                null
+            }
+        }
+}

--- a/app/src/main/java/com/sdvsync/download/GitHubReleaseChecker.kt
+++ b/app/src/main/java/com/sdvsync/download/GitHubReleaseChecker.kt
@@ -14,7 +14,8 @@ data class GitHubReleaseInfo(
     val assetUrl: String,
     val assetSize: Long,
     val assetName: String,
-    val publishedAt: String
+    val publishedAt: String,
+    val body: String = ""
 )
 
 class GitHubReleaseChecker(private val context: Context, private val httpClient: OkHttpClient) {
@@ -26,8 +27,10 @@ class GitHubReleaseChecker(private val context: Context, private val httpClient:
 
         const val CINDERBOX_REPO = "Ekyso/Cinderbox"
         const val SMAPI_REPO = "Ekyso/SMAPI-for-Cinderbox"
+        const val APP_REPO = "ObfuscatedVoid/Cinderbox-Companion"
         val CINDERBOX_ASSET_PATTERN = Regex("Cinderbox-.*\\.apk")
         val SMAPI_ASSET_PATTERN = Regex("smapi-internal\\.zip")
+        val APP_ASSET_PATTERN = Regex("CinderboxCompanion-.*\\.apk")
 
         const val KEY_CINDERBOX_VERSION = "cinderbox_installed_version"
         const val KEY_SMAPI_VERSION = "smapi_installed_version"
@@ -73,6 +76,7 @@ class GitHubReleaseChecker(private val context: Context, private val httpClient:
                 val json = JSONObject(body)
                 val tagName = json.getString("tag_name")
                 val publishedAt = json.optString("published_at", "")
+                val releaseBody = json.optString("body", "")
 
                 val assets = json.getJSONArray("assets")
                 var matchedInfo: GitHubReleaseInfo? = null
@@ -87,7 +91,8 @@ class GitHubReleaseChecker(private val context: Context, private val httpClient:
                             assetUrl = asset.getString("browser_download_url"),
                             assetSize = asset.getLong("size"),
                             assetName = name,
-                            publishedAt = publishedAt
+                            publishedAt = publishedAt,
+                            body = releaseBody
                         )
                         break
                     }
@@ -145,6 +150,7 @@ class GitHubReleaseChecker(private val context: Context, private val httpClient:
         put("assetSize", info.assetSize)
         put("assetName", info.assetName)
         put("publishedAt", info.publishedAt)
+        put("body", info.body)
     }.toString()
 
     private fun parseReleaseInfoFromCache(json: String): GitHubReleaseInfo? = try {
@@ -155,7 +161,8 @@ class GitHubReleaseChecker(private val context: Context, private val httpClient:
             assetUrl = obj.getString("assetUrl"),
             assetSize = obj.getLong("assetSize"),
             assetName = obj.getString("assetName"),
-            publishedAt = obj.optString("publishedAt", "")
+            publishedAt = obj.optString("publishedAt", ""),
+            body = obj.optString("body", "")
         )
     } catch (e: Exception) {
         null

--- a/app/src/main/java/com/sdvsync/ui/components/AppUpdateDialog.kt
+++ b/app/src/main/java/com/sdvsync/ui/components/AppUpdateDialog.kt
@@ -1,0 +1,200 @@
+package com.sdvsync.ui.components
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import com.sdvsync.download.GitHubReleaseInfo
+import com.sdvsync.ui.formatBytes
+import com.sdvsync.ui.viewmodels.AppUpdateState
+
+@Composable
+fun AppUpdateDialog(
+    updateInfo: GitHubReleaseInfo,
+    state: AppUpdateState,
+    onDismiss: () -> Unit,
+    onCancelDownload: () -> Unit,
+    onSkipVersion: () -> Unit,
+    onUpdate: () -> Unit,
+    onInstallPermissionGranted: () -> Unit
+) {
+    val context = LocalContext.current
+    val scale = remember { Animatable(0.92f) }
+
+    LaunchedEffect(Unit) {
+        scale.animateTo(
+            targetValue = 1f,
+            animationSpec = spring(dampingRatio = 0.7f, stiffness = 400f)
+        )
+    }
+
+    // Re-check install permission on resume
+    if (state.showInstallPermissionPrompt) {
+        LifecycleResumeEffect(Unit) {
+            onInstallPermissionGranted()
+            onPauseOrDispose {}
+        }
+    }
+
+    Dialog(onDismissRequest = { if (!state.isDownloading) onDismiss() }) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .pixelBorder()
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                },
+            shape = RectangleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                // Title row
+                Text(
+                    "↑ Update Available",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "v${updateInfo.version}  •  ${formatBytes(updateInfo.assetSize)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(Modifier.height(12.dp))
+
+                // Changelog
+                if (updateInfo.body.isNotBlank()) {
+                    Text(
+                        "What's New",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    val textColor = MaterialTheme.colorScheme.onSurface.toArgb()
+                    val linkColor = MaterialTheme.colorScheme.primary.toArgb()
+                    val html = markdownToHtml(updateInfo.body)
+                    HtmlText(
+                        html = html,
+                        textColor = textColor,
+                        linkColor = linkColor,
+                        textSizeSp = 13f,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 200.dp)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                }
+
+                // Progress bar (visible while downloading)
+                if (state.isDownloading) {
+                    val pct = (state.downloadProgress * 100).toInt()
+                    Text(
+                        "Downloading… $pct%",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    PixelProgressBar(progress = state.downloadProgress, modifier = Modifier.fillMaxWidth())
+                    Spacer(Modifier.height(12.dp))
+                }
+
+                // Error message
+                if (state.downloadError != null) {
+                    Text(
+                        state.downloadError,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Spacer(Modifier.height(8.dp))
+                }
+
+                // Buttons
+                Row(
+                    modifier = Modifier.align(Alignment.End),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (state.isDownloading) {
+                        TextButton(onClick = onCancelDownload) {
+                            Text("Cancel")
+                        }
+                    } else {
+                        TextButton(onClick = onSkipVersion) {
+                            Text(
+                                "Skip version",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(Modifier.width(4.dp))
+                        StardewButton(onClick = onDismiss) {
+                            Text("Later")
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        when {
+                            state.downloadError != null -> {
+                                StardewButton(onClick = onUpdate, variant = StardewButtonVariant.Action) {
+                                    Text("Retry")
+                                }
+                            }
+                            state.showInstallPermissionPrompt -> {
+                                StardewButton(
+                                    onClick = {
+                                        val intent = Intent(
+                                            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                                            Uri.parse("package:${context.packageName}")
+                                        )
+                                        context.startActivity(intent)
+                                    },
+                                    variant = StardewButtonVariant.Action
+                                ) {
+                                    Text("Allow installs →")
+                                }
+                            }
+                            else -> {
+                                StardewButton(onClick = onUpdate, variant = StardewButtonVariant.Action) {
+                                    Text("Update ▶")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Auto-install when APK is ready
+    val downloadedApk = state.downloadedApk
+    if (downloadedApk != null) {
+        LaunchedEffect(downloadedApk) {
+            installCinderboxApk(context, downloadedApk)
+            onDismiss()
+        }
+    }
+}

--- a/app/src/main/java/com/sdvsync/ui/components/HtmlText.kt
+++ b/app/src/main/java/com/sdvsync/ui/components/HtmlText.kt
@@ -7,6 +7,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.text.HtmlCompat
 
+fun markdownToHtml(md: String): String {
+    var html = md
+    // Headings: ## Heading → <b>Heading</b>
+    html = html.replace(Regex("^#{1,6}\\s+(.+)$", RegexOption.MULTILINE)) { "<b>${it.groupValues[1]}</b>" }
+    // Bold
+    html = html.replace(Regex("\\*\\*(.+?)\\*\\*")) { "<b>${it.groupValues[1]}</b>" }
+    // Italic
+    html = html.replace(Regex("\\*(.+?)\\*")) { "<i>${it.groupValues[1]}</i>" }
+    // Unordered list items: - item or * item → • item
+    html = html.replace(Regex("^[-*]\\s+(.+)$", RegexOption.MULTILINE)) { "&#8226; ${it.groupValues[1]}" }
+    // Newlines → <br>
+    html = html.replace("\r\n", "<br>").replace("\n", "<br>")
+    return html
+}
+
 val HTML_TAG_REGEX = Regex("<[a-zA-Z/]")
 val BBCODE_TAG_REGEX = Regex(
     "\\[(?:b|i|u|s|url|img|size|color|font|list|quote|code|center|spoiler|line|heading)[=\\]/]",

--- a/app/src/main/java/com/sdvsync/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/sdvsync/ui/screens/SettingsScreen.kt
@@ -412,6 +412,30 @@ fun SettingsScreen(onBack: () -> Unit, onLogout: () -> Unit, viewModel: Settings
                             }
                         }
                     }
+
+                    Spacer(Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                "Check for app updates",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                "Show update dialog on login when a new version is available",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(Modifier.width(12.dp))
+                        Switch(
+                            checked = state.updateCheckEnabled,
+                            onCheckedChange = { viewModel.toggleUpdateCheck(it) },
+                            colors = switchColors
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/sdvsync/ui/viewmodels/AppUpdateViewModel.kt
+++ b/app/src/main/java/com/sdvsync/ui/viewmodels/AppUpdateViewModel.kt
@@ -1,0 +1,110 @@
+package com.sdvsync.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sdvsync.download.AppUpdateManager
+import com.sdvsync.download.GitHubReleaseChecker
+import com.sdvsync.download.GitHubReleaseInfo
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AppUpdateState(
+    val updateInfo: GitHubReleaseInfo? = null,
+    val showDialog: Boolean = false,
+    val showInstallPermissionPrompt: Boolean = false,
+    val isDownloading: Boolean = false,
+    val downloadProgress: Float = 0f,
+    val downloadedApk: File? = null,
+    val downloadError: String? = null
+)
+
+class AppUpdateViewModel(
+    private val updateManager: AppUpdateManager,
+    private val releaseChecker: GitHubReleaseChecker
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AppUpdateState())
+    val state: StateFlow<AppUpdateState> = _state.asStateFlow()
+
+    private var downloadJob: Job? = null
+
+    fun checkForUpdate() {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val info = releaseChecker.getLatestRelease(
+                    GitHubReleaseChecker.APP_REPO,
+                    GitHubReleaseChecker.APP_ASSET_PATTERN
+                ) ?: return@launch
+
+                if (updateManager.shouldShowUpdate(info.version)) {
+                    _state.update { it.copy(updateInfo = info, showDialog = true) }
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (_: Exception) { }
+        }
+    }
+
+    fun dismiss() {
+        _state.update { it.copy(showDialog = false, downloadedApk = null) }
+    }
+
+    fun cancelDownload() {
+        downloadJob?.cancel()
+        downloadJob = null
+        _state.update {
+            it.copy(isDownloading = false, downloadProgress = 0f, downloadedApk = null, showDialog = false)
+        }
+    }
+
+    fun skipVersion() {
+        val version = _state.value.updateInfo?.version ?: return
+        updateManager.setSkippedVersion(version)
+        _state.update { it.copy(showDialog = false) }
+    }
+
+    fun startDownload() {
+        if (!updateManager.canInstallPackages()) {
+            _state.update { it.copy(showInstallPermissionPrompt = true) }
+            return
+        }
+        val info = _state.value.updateInfo ?: return
+        _state.update {
+            it.copy(
+                isDownloading = true,
+                downloadProgress = 0f,
+                downloadError = null,
+                downloadedApk = null,
+                showInstallPermissionPrompt = false
+            )
+        }
+        downloadJob = viewModelScope.launch {
+            val apk = updateManager.downloadUpdate(info.assetUrl, info.assetName) { progress ->
+                _state.update { it.copy(downloadProgress = progress) }
+            }
+            if (apk != null) {
+                _state.update { it.copy(isDownloading = false, downloadedApk = apk) }
+            } else {
+                _state.update { it.copy(isDownloading = false, downloadError = "Download failed. Tap to retry.") }
+            }
+        }
+    }
+
+    fun retryDownload() {
+        _state.update { it.copy(downloadError = null) }
+        startDownload()
+    }
+
+    fun onInstallPermissionGranted() {
+        _state.update { it.copy(showInstallPermissionPrompt = false) }
+        if (updateManager.canInstallPackages()) {
+            startDownload()
+        }
+    }
+}

--- a/app/src/main/java/com/sdvsync/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/sdvsync/ui/viewmodels/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sdvsync.autosync.AutoSyncService
+import com.sdvsync.download.AppUpdateManager
 import com.sdvsync.download.GitHubReleaseChecker
 import com.sdvsync.fileaccess.AllFilesAccess
 import com.sdvsync.fileaccess.FileAccessDetector
@@ -51,7 +52,8 @@ data class SettingsState(
     val latestCinderboxVersion: String? = null,
     val latestSmapiVersion: String? = null,
     val cinderboxUpdateAvailable: Boolean = false,
-    val smapiUpdateAvailable: Boolean = false
+    val smapiUpdateAvailable: Boolean = false,
+    val updateCheckEnabled: Boolean = true
 )
 
 class SettingsViewModel(
@@ -61,7 +63,8 @@ class SettingsViewModel(
     private val backupManager: SaveBackupManager,
     private val modDataStore: ModDataStore,
     private val nexusSource: NexusModSource,
-    private val releaseChecker: GitHubReleaseChecker
+    private val releaseChecker: GitHubReleaseChecker,
+    private val appUpdateManager: AppUpdateManager
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -102,7 +105,8 @@ class SettingsViewModel(
             hasNexusApiKey = apiKey != null,
             nexusApiKeyMasked = maskedKey,
             installedCinderboxVersion = installedCinderbox,
-            installedSmapiVersion = installedSmapi
+            installedSmapiVersion = installedSmapi,
+            updateCheckEnabled = appUpdateManager.isUpdateCheckEnabled()
         )
 
         // Load latest versions in background
@@ -212,5 +216,10 @@ class SettingsViewModel(
 
     fun clearApiKeyError() {
         _state.update { it.copy(apiKeyError = null) }
+    }
+
+    fun toggleUpdateCheck(enabled: Boolean) {
+        appUpdateManager.setUpdateCheckEnabled(enabled)
+        _state.update { it.copy(updateCheckEnabled = enabled) }
     }
 }


### PR DESCRIPTION
feat: add in-app auto-update with download and install

Check GitHub Releases for new versions on app launch, show update dialog with changelog, download APK with progress, and trigger install. Includes skip version, disable toggle in settings, and install permission handling.

Bump version to 0.0.7.